### PR TITLE
feat: 전체 게시글 페이지 추가

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.11.45",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
+        "axios": "^0.27.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
@@ -5004,6 +5005,28 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -29291,6 +29314,27 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.11.45",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,25 +1,18 @@
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import AllPost from './pages/allPost';
+import Post from './pages/post';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path='/' element={<AllPost/>} />
+        <Route path='/post' element={<Post/>} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/client/src/components/ pagination.tsx
+++ b/client/src/components/ pagination.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+type Props = {
+  contentsCount: number;
+  postLimit: number;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export default function Pagination({ contentsCount, postLimit, page, setPage }: Props) {
+  const pageCount = new Array(Math.ceil(contentsCount / postLimit)).fill(false);
+
+  function changePage(pageNumber: number) {
+    if (pageNumber <= 0 || pageNumber > pageCount.length) return;
+    setPage(pageNumber);
+  }
+  
+  return (
+    <div>
+      <ul>
+        <li>
+          <button onClick={()=>changePage(page - 1)}>pre</button>
+        </li>
+        {pageCount.map((_, idx) => (
+          <li key={idx}>
+            <button onClick={()=>changePage(idx + 1)}>{idx + 1}</button>
+          </li>
+        ))}
+        <li>
+          <button onClick={()=>changePage(page + 1)}>next</button>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/ pagination.tsx
+++ b/client/src/components/ pagination.tsx
@@ -19,15 +19,15 @@ export default function Pagination({ contentsCount, postLimit, page, setPage }: 
     <div>
       <ul>
         <li>
-          <button onClick={()=>changePage(page - 1)}>pre</button>
+          <button onClick={() => changePage(page - 1)}>pre</button>
         </li>
         {pageCount.map((_, idx) => (
           <li key={idx}>
-            <button onClick={()=>changePage(idx + 1)}>{idx + 1}</button>
+            <button onClick={() => changePage(idx + 1)}>{idx + 1}</button>
           </li>
         ))}
         <li>
-          <button onClick={()=>changePage(page + 1)}>next</button>
+          <button onClick={() => changePage(page + 1)}>next</button>
         </li>
       </ul>
     </div>

--- a/client/src/components/searchBar.tsx
+++ b/client/src/components/searchBar.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { SearchValue } from '../pages/allPost';
+
+type Props = {
+  searchValue: SearchValue;
+  setSearchValue: React.Dispatch<React.SetStateAction<SearchValue>>;
+}
+
+export default function SearchBar({ searchValue, setSearchValue }: Props) {
+  const [inputValue, setInputValue] = useState('');
+  const searchTargets = ['userId', 'title'];
+
+  function handleSearchOption(e: React.ChangeEvent<HTMLSelectElement>) {
+    if (e.target.value !== 'userId' && e.target.value !== 'title') return;
+
+    setSearchValue({
+      ...searchValue,
+      target: e.target.value,
+    });
+  }
+
+  function handleSearchValue(e: React.ChangeEvent<HTMLInputElement>) {
+    setInputValue(e.target.value);
+    setSearchValue({
+      ...searchValue,
+      value: e.target.value,
+    });
+  }
+
+  return (
+    <div>
+      <select onChange={(e) => handleSearchOption(e)}>
+        {searchTargets.map((value, idx) => (
+          <option key={idx}>{value}</option>
+        ))}
+      </select>
+
+      <input onChange={(e) => handleSearchValue(e)} value={inputValue}></input>
+    </div>
+  );
+}

--- a/client/src/modals/userInfo.tsx
+++ b/client/src/modals/userInfo.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function UserInfo() {
+  
+  return (
+    <div>
+      userInfo
+    </div>
+  );
+}

--- a/client/src/pages/allPost.tsx
+++ b/client/src/pages/allPost.tsx
@@ -17,6 +17,7 @@ export default function AllPost() {
   const [postLimit, setPostLimit] = useState(20);
   const start = (page - 1) * postLimit;
   const end = start + postLimit;
+  const postLimitOptions = [10, 20, 50, 100];
 
   useEffect(() => {
     axios
@@ -32,10 +33,23 @@ export default function AllPost() {
   function handlePostClick(post: Post) {
     nav('/post', { state: post });
   }
+
+  function handlePostLimitOption(e: React.ChangeEvent<HTMLSelectElement>) {
+    setPostLimit(Number(e.target.value));
+  }
   
   return (
     <div>
       <h1>전체 게시판</h1>
+
+      <div>
+        <select onChange={(e)=>handlePostLimitOption(e)}>
+          {postLimitOptions.map((value, idx) => (
+            <option key={idx}>{value}</option>
+          ))}
+        </select>
+      </div>
+
       <ul>
         {posts.slice(start, end).map(post => (
           <li key={post.id}>

--- a/client/src/pages/allPost.tsx
+++ b/client/src/pages/allPost.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import Pagination from '../components/ pagination';
 
 type Post = {
   id: number;
@@ -12,12 +13,15 @@ type Post = {
 export default function AllPost() {
   const nav = useNavigate();
   const [posts, setPosts] = useState<Post[]>([]);
+  const [page, setPage] = useState(1);
+  const [postLimit, setPostLimit] = useState(20);
+  const start = (page - 1) * postLimit;
+  const end = start + postLimit;
 
   useEffect(() => {
     axios
       .get("https://jsonplaceholder.typicode.com/posts")
       .then(res => {
-        console.log(res.data);
         setPosts(res.data);
       })
       .catch(err => {
@@ -33,17 +37,19 @@ export default function AllPost() {
     <div>
       <h1>전체 게시판</h1>
       <ul>
-        <li>
-          <p>제목</p>
-          <p>작성자</p>
-        </li>
-        {posts.map(post => (
-          <li key={post.id} onClick={() => handlePostClick(post)}>
-            <p>{post.title}</p>
+        {posts.slice(start, end).map(post => (
+          <li key={post.id}>
+            <p onClick={() => handlePostClick(post)}>{post.title}</p>
             <p>작성자 {post.userId}</p>
           </li>
         ))}
       </ul>
+      <Pagination 
+        contentsCount={posts.length}
+        postLimit={postLimit}
+        setPage={setPage}
+        page={page}
+      />
     </div>
   );
 }

--- a/client/src/pages/allPost.tsx
+++ b/client/src/pages/allPost.tsx
@@ -1,0 +1,49 @@
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type Post = {
+  id: number;
+  userId: number;
+  title: string;
+  body: string;
+}
+
+export default function AllPost() {
+  const nav = useNavigate();
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    axios
+      .get("https://jsonplaceholder.typicode.com/posts")
+      .then(res => {
+        console.log(res.data);
+        setPosts(res.data);
+      })
+      .catch(err => {
+        console.log(err.message);
+      });
+  }, []);
+
+  function handlePostClick(post: Post) {
+    nav('/post', { state: post });
+  }
+  
+  return (
+    <div>
+      <h1>전체 게시판</h1>
+      <ul>
+        <li>
+          <p>제목</p>
+          <p>작성자</p>
+        </li>
+        {posts.map(post => (
+          <li key={post.id} onClick={() => handlePostClick(post)}>
+            <p>{post.title}</p>
+            <p>작성자 {post.userId}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/pages/post.tsx
+++ b/client/src/pages/post.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Post() {
+  
+  return (
+    <div>
+      post
+    </div>
+  );
+}


### PR DESCRIPTION
### PR 타입
- 기능 추가

### 반영 브랜치
feat -> dev

### 변경 사항
- ### 전체 게시글
  - 전체 게시글 데이터를 받아와 표시하는 페이지
- ### 페이지네이션 기능
  - 페이지당 게시글 수 선택 가능(기본 10개)
  - 페이지당 게시글 수에 따라 페이지네이션 생성 
- ### 검색 기능
  - 유저 아이디 또는 제목으로 검색 가능
  -  게시글과 페이지네이션도 검색 결과에 맞게 변경됨
  
### 테스트 결과
1. 게시글 데이터 받아오기 - 정상
2. 페이지 버튼을 눌렀을때 게시글 변경 - 정상
3. 페이지당 게시글 수 변경시 페이지네이션 변경 - 정상
4. 검색 후 결과에 따라 게시글과 페이지 네이션 변경 - 정상
5. 페이지네이션 또는 검색 기능으로 게시글에 변경이 생기면 1페이지 부터 보여줌 - 정상